### PR TITLE
Develop

### DIFF
--- a/oauth2client/contrib/django_util/__init__.py
+++ b/oauth2client/contrib/django_util/__init__.py
@@ -230,7 +230,7 @@ import importlib
 
 import django.conf
 from django.core import exceptions
-from django.urls import urlresolvers
+from django.urls import resolvers
 from six.moves.urllib import parse
 
 from oauth2client import clientsecrets

--- a/oauth2client/contrib/django_util/views.py
+++ b/oauth2client/contrib/django_util/views.py
@@ -26,7 +26,7 @@ import os
 from django import http
 from django import shortcuts
 from django.conf import settings
-from django.urls import urlresolvers
+from django.urls import resolvers
 from django.shortcuts import redirect
 from django.utils import html
 import jsonpickle


### PR DESCRIPTION
**Note**: oauth2client is now deprecated. As such, it is unlikely that we will
review or merge to your pull request. We recommend you use
[google-auth](https://google-auth.readthedocs.io) and [oauthlib](http://oauthlib.readthedocs.io/).
